### PR TITLE
add end to booking_params method

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -35,6 +35,7 @@ class BookingsController < ApplicationController
 
   def booking_params
     params.require(:booking).permit(:start_date, :end_date, :price, :description)
+  end
 
 end
 


### PR DESCRIPTION
le bug de déploiment sur Heroku vient surement d'un end manquant dans le controller bookings.